### PR TITLE
Fix install guide link

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
                 Getting Started
             </header>
             <p>
-                Want to <b>install Digital Rebar</b>? Here's the <a href="http://digital-rebar.readthedocs.org/en/latest/deployment/install.html">Install Guide</a> (<a href="http://digital-rebar.readthedocs.org/en/latest/deployment/install/quick.html">AWS Quick Start</a>).
+                Want to <b>install Digital Rebar</b>? Here's the <a href="http://digital-rebar.readthedocs.io/en/latest/deployment/README.html">Install Guide</a> (<a href="http://digital-rebar.readthedocs.org/en/latest/deployment/install/quick.html">AWS Quick Start</a>).
             </p><br/>
             <ul>
                 <li><a href="https://www.youtube.com/playlist?list=PLXPBeIrpXjfh2lXdXkNnzAuc7_SUtYJR-">Demo Videos!</a></li>


### PR DESCRIPTION
http://digital-rebar.readthedocs.io/en/latest/deployment/install.html doesn't exist, pointing to http://digital-rebar.readthedocs.io/en/latest/deployment/README.html