### PR TITLE
Clean up welcome message to be more generic; add Slack signup link

### DIFF
--- a/community/welcome.html
+++ b/community/welcome.html
@@ -62,7 +62,7 @@
 
       <img src="../dr_provision.png" class="bear-image" align="right" style="max-width: 200px;">
       <p>
-        Welcome to the Digital Rebar #community slack channel!   
+        Welcome to the Digital Rebar community!   
       </p>
       <p>
         We look forward to your participation in our community conversations, and hope that your participation will be both rewarding for you, and also provide value to our community. Participation at all levels within the community is encouraged!  
@@ -76,6 +76,12 @@
           <li>Submit detailed <a href="https://github.com/digitalrebar/provision/issues/new">Issues and Enhancement requests</a> when relevant</li>
           <li>Submit Pull Requests for updates to Documentation, Features, or Enhancements </li>
           <li>HAVE FUN !!</li>
+        </ul>
+      </p>
+      <p>
+        If you haven't yet signed up for a Slack account, you can do so by filling out the form, located at:
+        <ul>
+          <li><a href="https://www.rackn.com/support/slack/"> Join our Slack Community</a></li>
         </ul>
       </p>
       <p>


### PR DESCRIPTION
- basic cleanup to make welcome message more generic (users don't always come from #community welcome)
- add link to Signup for Slack account in case someone lands on this page, but doesn't yet have Slack account
