### PR TITLE
Update 'Getting Started' Icons/Links (ver3)

### DIFF
--- a/community/welcome.html
+++ b/community/welcome.html
@@ -91,6 +91,15 @@
         <div class="getting-started" alt="Code of Conduct" onclick="displayClick(event, this)" url="code_of_conduct.html">
           <i class="material-icons">playlist_add_check</i>
         </div>
+        <div class="getting-started" alt="Demo Videos" onclick="displayClick(event, this)" url="https://www.youtube.com/playlist?list=PLXPBeIrpXjfj5_8Joyehwq1nnaYSPCnmw">
+          <i class="material-icons">video_library</i>
+        </div>
+        <div class="getting-started" alt="Slack Messaging" onclick="displayClick(event, this)" url="https://rackn.com/support/slack">
+          <i class="material-icons">forum</i>
+        </div>
+        <div class="getting-started" alt="Web Portal" onclick="displayClick(event, this)" url="https://portal.rackn.io/#/">
+          <i class="material-icons">web</i>
+        </div>
         <div class="getting-started noclick" alt="Install Guide" onclick="">
           <i class="material-icons">file_download</i>
           <div class="dropdown">
@@ -105,21 +114,6 @@
             </div>
           </div>
         </div>
-        <div class="getting-started" alt="Demo Videos" onclick="displayClick(event, this)" url="https://www.youtube.com/playlist?list=PLXPBeIrpXjfj5_8Joyehwq1nnaYSPCnmw">
-          <i class="material-icons">video_library</i>
-        </div>
-        <div class="getting-started" alt="Mailing List" onclick="displayClick(event, this)" url="http://bit.ly/digitalrebarlist">
-          <i class="material-icons">mail</i>
-        </div>
-        <div class="getting-started" alt="Live Chat (Gitter)" onclick="displayClick(event, this)" url="https://gitter.im/digitalrebar/core?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge">
-          <i class="material-icons">forum</i>
-        </div>
-        <div class="getting-started" alt="IRC (Freenode)" onclick="displayClick(event, this)" url="https://webchat.freenode.net/?channels=%23digitalrebar&uio=d4">
-          <i class="material-icons">chat</i>
-        </div>
-        <div class="getting-started" alt="Issues &amp; Roadmap" onclick="displayClick(event, this)" url="https://github.com/digitalrebar/provision/issues">
-          <i class="material-icons">directions</i>
-        </div>
         <div class="getting-started noclick" alt="Documentation" onclick="">
           <i class="material-icons">book</i>
           <div class="dropdown">
@@ -130,9 +124,15 @@
               Git Repo
             </div>
             <div class="dropdown-link" onclick="displayClick(event, this)" url="http://provision.readthedocs.org/en/latest/">
-              Documentation
+              Full Docs
             </div>
           </div>
+        </div>
+        <div class="getting-started" alt="Issues &amp; Roadmap" onclick="displayClick(event, this)" url="https://github.com/digitalrebar/provision/issues">
+          <i class="material-icons">directions</i>
+        </div>
+        <div class="getting-started" alt="GitHub Repo" onclick="displayClick(event, this)" url="https://github.com/digitalrebar/provision">
+          <i class="material-icons">code</i>
         </div>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link href="https://www.google.com/fonts#UsePlace:use/Collection:Roboto+Mono" rel="stylesheet" type="text/css" />
     <link href="https://www.google.com/fonts#UsePlace:use/Collection:Allerta+Stencil" rel="stylesheet" type="text/css" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" type="text/css" />
+    <!-- material-icons reference: https://material.io/icons/ -->
     <link href="digitalrebar.ico" rel="SHORTCUT ICON" />
     <meta name="google-site-verification" content="zCf79OnCmnSaInCAHjC8bfWcYvMXXzTfjx_fG_k-6AM" />
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
@@ -94,42 +95,35 @@
         <a class="anchor" name="starting"></a>
         <h2>Getting Started</h2>
         <div class="getting-started-container">
-          <div class="getting-started noclick" alt="Install Guide" onclick="">
-            <i class="material-icons">file_download</i>
-            <div class="dropdown">
-              <div class="dropdown-link" onclick="displayClick(event, this)" url="http://provision.readthedocs.io/en/latest/doc/install.html">
-                Install Guide
-              </div>
-              <div class="dropdown-link" onclick="displayClick(event, this)" url="http://provision.readthedocs.io/en/latest/doc/quickstart.html">
-                Quick Start
-              </div>
-            </div>
-          </div>
-          <div class="getting-started" alt="Demo Videos" onclick="displayClick(event, this)" url="https://www.youtube.com/playlist?list=PLXPBeIrpXjfj5_8Joyehwq1nnaYSPCnmw">
+          <div class="getting-started" alt="Demo Videos" onclick="displayClick(event, this)" url="https://www.youtube.com/playlist?                                        list=PLXPBeIrpXjfj5_8Joyehwq1nnaYSPCnmw">
             <i class="material-icons">video_library</i>
           </div>
-          <div class="getting-started" alt="Slack (Primary)" onclick="displayClick(event, this)" url="https://rackn.com/support/slack">
+          <div class="getting-started" alt="Slack Messaging" onclick="displayClick(event, this)" url="https://rackn.com/support/slack">
             <i class="material-icons">forum</i>
-          </div>
-          <div class="getting-started" alt="Gitter (Alternative)" onclick="displayClick(event, this)" url="https://gitter.im/digitalrebar/core?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge">
-            <i class="material-icons">chat</i>
-          </div>
-          <div class="getting-started" alt="Issues &amp; Roadmap" onclick="displayClick(event, this)" url="https://github.com/digitalrebar/provision/issues">
-            <i class="material-icons">directions</i>
           </div>
           <div class="getting-started noclick" alt="Documentation" onclick="">
             <i class="material-icons">book</i>
             <div class="dropdown">
-              <div class="dropdown-link" onclick="displayClick(event, this)" url="https://readthedocs.org/projects/provision/downloads/pdf/latest/">
-                Single PDF
-              </div>
-              <div class="dropdown-link" onclick="displayClick(event, this)" url="https://github.com/digitalrebar/provision/tree/master/doc">
-                Git Repo
-              </div>
               <div class="dropdown-link" onclick="displayClick(event, this)" url="http://provision.readthedocs.org/en/latest/">
-                Documentation
+                Full Docs
+              </div>
+              <div class="dropdown-link" onclick="displayClick(event, this)" url="http://provision.readthedocs.io/en/latest/doc/install.html">
+                Install Guide
+              </div>
+              <div class="dropdown-link" onclick="displayClick(event, this)" url="http://provision.readthedocs.io/en/latest/doc/quickstart.html">
+                QuickStart
+              </div>
               </div>
             </div>
+          <div class="getting-started" alt="Issues &amp; Roadmap" onclick="displayClick(event, this)" url="https://github.com/digitalrebar/provision/issues">
+            <i class="material-icons">directions</i>
+          </div>
+          <div class="getting-started" alt="GitHub Repo" onclick="displayClick(event, this)" url="https://github.com/digitalrebar/provision">
+            <i class="material-icons">code</i>
+          </div>
+          <div class="getting-started" alt="Web Portal" onclick="displayClick(event, this)" url="https://portal.rackn.io/#/">
+            <i class="material-icons">web</i>
+          </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
- ver3 attempt at this ... 
- cleanup the `getting started` section icons and links
- added Github, Portal, etc.
- removed Gitter
- updated `community/welcome.html` as well 
