### PR TITLE
Updated URL reference for LICENSE

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
         <a class="anchor" name="sponsor"></a>
         <h2>Project Sponsored by <a href="http://rackn.com">RackN</a></h2>
         <p>
-          Digital Rebar Provision is an <a href="https://github.com/digitalrebar/provision/blob/master/LICENSE.rst">Apache2 licensed</a> Project. As the community sponsor, RackN provides day to day management of the community including the GitHub site, development activities and community promotion. Additionally, <a href="https://www.rackn.com/products/">RackN</a> offers commerical support, custom integrations, training, and advanced technology for Digital Rebar Provision users interested in extending the open source feature set.
+          Digital Rebar Provision is an <a href="https://github.com/digitalrebar/provision/blob/master/LICENSE">Apache2 licensed</a> Project. As the community sponsor, RackN provides day to day management of the community including the GitHub site, development activities and community promotion. Additionally, <a href="https://www.rackn.com/products/">RackN</a> offers commerical support, custom integrations, training, and advanced technology for Digital Rebar Provision users interested in extending the open source feature set.
         </p>
         <p>
         <b>Additional RackN Features</b>


### PR DESCRIPTION
- was pointing to `LICENSE.rst` which had been moved to just `LICENSE`