### PR TITLE
Redirects for welcome.html

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+plugins:
+  - jekyll-redirect-from

--- a/welcome.html
+++ b/welcome.html
@@ -1,3 +1,6 @@
+---
+redirect_from: "/community/welcome.html"
+---
 <!DOCTYPE html>
 <html>
   <head>


### PR DESCRIPTION
* adds jekyl redirect_from gem config
* sets up redirect from old /community/welcome.html to welcome.html

Tested on `sygibson.github.io/community/welcome.html` which redirects to `sygibson.github.io/index.html`